### PR TITLE
Upgraded pyIndego and two minor typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Copy the folder `indego` in `custom_components` into your `custom_components` in
 Reboot HA in order to get HA to find the newly added custom component.
 
 ## Configuration
-Add the domain to your configuration.yaml. Username, password and id (serial) is mandatory. Name (default = Indego) and polling (default = false) is optional.
+Add the domain to your configuration.yaml. Username, password and id (serial) is mandatory. Name is optional (default = Indego).
 ``` yaml
 #configuration.yaml
 indego:
@@ -41,7 +41,7 @@ indego_id:       "123456789"
 ## Usage
 
 ### Entities
- All sensors are auto discovered and should appear as "unused entities" after adding the component.
+ All sensors are autodiscovered and should appear as "unused entities" after adding the component.
 
 | Description | Screenshot |
 |-------------|------------|

--- a/custom_components/indego/manifest.json
+++ b/custom_components/indego/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/jm-73/Indego",
   "dependencies": [],
   "codeowners": ["@jm-73", "@eavanvalkenburg"],
-  "requirements": ["pyIndego==2.0.29"],
-  "version": "3.8.0"
+  "requirements": ["pyIndego==2.0.30"],
+  "version": "3.8.1"
 }


### PR DESCRIPTION
Bosch have made changes to the API Therefor the pyIndego had to be updated to support the new syntax of the API.