### PR TITLE
Renamed deprecated property device_state_attributes

### DIFF
--- a/custom_components/indego/binary_sensor.py
+++ b/custom_components/indego/binary_sensor.py
@@ -103,7 +103,7 @@ class IndegoBinarySensor(BinarySensorEntity, RestoreEntity):
         return self._icon
 
     @property
-    def device_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict:
         """Return attributes."""
         return self._attr
 

--- a/custom_components/indego/sensor.py
+++ b/custom_components/indego/sensor.py
@@ -107,7 +107,7 @@ class IndegoSensor(RestoreEntity):
         return self._device_class
 
     @property
-    def device_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict:
         """Return attributes."""
         return self._attr
 


### PR DESCRIPTION
With https://github.com/home-assistant/core/pull/47304 the deprecated property `device_state_attributes` has been renamed to `extra_state_attributes`.

It was set to deprecatey by December 2021. Apparently since 2022.04 the support for `device_state_attributes` has been removed.

After changing the attributes are back again.