### PR TITLE
Change TEMP_CELSIUS to UnitOfTemperature

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -9,8 +9,7 @@ from homeassistant.core import HomeAssistant, CoreState
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_CONNECTIVITY,
-    DEVICE_CLASS_PROBLEM,
+    BinarySensorDeviceClass,
 )
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
@@ -95,7 +94,7 @@ ENTITY_DEFINITIONS = {
         CONF_TYPE: BINARY_SENSOR_TYPE,
         CONF_NAME: "online",
         CONF_ICON: "mdi:cloud-check",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_CONNECTIVITY,
+        CONF_DEVICE_CLASS: BinarySensorDeviceClass.CONNECTIVITY,
         CONF_ATTR: [],
     },
     ENTITY_UPDATE_AVAILABLE: {
@@ -109,7 +108,7 @@ ENTITY_DEFINITIONS = {
         CONF_TYPE: BINARY_SENSOR_TYPE,
         CONF_NAME: "alert",
         CONF_ICON: FUNC_ICON_MOWER_ALERT,
-        CONF_DEVICE_CLASS: DEVICE_CLASS_PROBLEM,
+        CONF_DEVICE_CLASS: BinarySensorDeviceClass.PROBLEM,
         CONF_ATTR: ["alerts_count"],
     },
     ENTITY_MOWER_STATE: {

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     STATE_ON,
     STATE_UNKNOWN,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_call_later
@@ -143,8 +143,8 @@ ENTITY_DEFINITIONS = {
             "voltage_V",
             "discharge_Ah",
             "cycles",
-            f"battery_temp_{TEMP_CELSIUS}",
-            f"ambient_temp_{TEMP_CELSIUS}",
+            f"battery_temp_{UnitOfTemperature.CELSIUS}",
+            f"ambient_temp_{UnitOfTemperature.CELSIUS}",
         ],
     },
     ENTITY_LAWN_MOWED: {
@@ -565,8 +565,8 @@ class IndegoHub:
                     "voltage_V": self._indego_client.operating_data.battery.voltage,
                     "discharge_Ah": self._indego_client.operating_data.battery.discharge,
                     "cycles": self._indego_client.operating_data.battery.cycles,
-                    f"battery_temp_{TEMP_CELSIUS}": self._indego_client.operating_data.battery.battery_temp,
-                    f"ambient_temp_{TEMP_CELSIUS}": self._indego_client.operating_data.battery.ambient_temp,
+                    f"battery_temp_{UnitOfTemperature.CELSIUS}": self._indego_client.operating_data.battery.battery_temp,
+                    f"ambient_temp_{UnitOfTemperature.CELSIUS}": self._indego_client.operating_data.battery.ambient_temp,
                 }
             )
 


### PR DESCRIPTION
I just saw the following warning in my system:
"TEMP_CELSIUS was used from indego, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'indego' custom integration"

So i changed TEMP_CELSIUS to UnitOfTemperature

Update: 
Just saw that also DEVICE_CLASS_CONNECTIVITY and DEVICE_CLASS_PROBLEM will be removed so changed these to BinarySensorDeviceClass.CONNECTIVITY and BinarySensorDeviceClass.PROBLEM