### PR TITLE
Feature/lawn mower entity

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -36,10 +36,12 @@ from pyIndego import IndegoAsyncClient
 from .api import IndegoOAuth2Session
 from .binary_sensor import IndegoBinarySensor
 from .vacuum import IndegoVacuum
+from .lawn_mower import IndegoLawnMower
 from .const import (
     STATUS_UPDATE_FAILURE_DELAY_TIME,
     BINARY_SENSOR_TYPE,
     VACUUM_TYPE,
+    LAWN_MOWER_TYPE,
     CONF_MOWER_SERIAL,
     CONF_MOWER_NAME,
     CONF_USER_AGENT,
@@ -73,6 +75,7 @@ from .const import (
     ENTITY_RUNTIME,
     ENTITY_UPDATE_AVAILABLE,
     ENTITY_VACUUM,
+    ENTITY_LAWN_MOWER,
     INDEGO_PLATFORMS,
     SENSOR_TYPE,
     SERVICE_NAME_COMMAND,
@@ -310,6 +313,9 @@ ENTITY_DEFINITIONS = {
     },
     ENTITY_VACUUM: {
         CONF_TYPE: VACUUM_TYPE,
+    },
+    ENTITY_LAWN_MOWER: {
+        CONF_TYPE: LAWN_MOWER_TYPE,
     },
 }
 
@@ -550,6 +556,14 @@ class IndegoHub:
                     self
                 )
 
+            elif entity[CONF_TYPE] == LAWN_MOWER_TYPE:
+                self.entities[entity_key] = IndegoLawnMower(
+                    f"indego_{self._serial}",
+                    self._mower_name,
+                    device_info,
+                    self
+                )
+
     async def update_generic_data_and_load_platforms(self, load_platforms):
         """Update the generic mower data, so we can create the HA platforms for the Indego component."""
         _LOGGER.debug("Getting generic data for device info.")
@@ -781,6 +795,7 @@ class IndegoHub:
         )
 
         self.entities[ENTITY_VACUUM].indego_state = self._indego_client.state.state
+        self.entities[ENTITY_LAWN_MOWER].indego_state = self._indego_client.state.state
 
         self.entities[ENTITY_LAWN_MOWED].add_attribute(
             {

--- a/custom_components/indego/const.py
+++ b/custom_components/indego/const.py
@@ -37,7 +37,8 @@ SERVICE_NAME_READ_ALERT_ALL: Final = "read_alert_all"
 SENSOR_TYPE: Final = "sensor"
 BINARY_SENSOR_TYPE: Final = "binary_sensor"
 VACUUM_TYPE: Final = "vacuum"
-INDEGO_PLATFORMS: Final = [SENSOR_TYPE, BINARY_SENSOR_TYPE, VACUUM_TYPE]
+LAWN_MOWER_TYPE: Final = "lawn_mower"
+INDEGO_PLATFORMS: Final = [SENSOR_TYPE, BINARY_SENSOR_TYPE, VACUUM_TYPE, LAWN_MOWER_TYPE]
 
 ENTITY_ONLINE: Final = "online"
 ENTITY_UPDATE_AVAILABLE: Final = "update_available"
@@ -63,5 +64,6 @@ ENTITY_MOWING_MODE: Final = "mowing_mode"
 ENTITY_RUNTIME: Final = "runtime_total"
 ENTITY_MOWER_ALERT: Final = "mower_alert"
 ENTITY_VACUUM: Final = "vacuum"
+ENTITY_LAWN_MOWER: Final = "lawn_mower"
 
 HTTP_HEADER_USER_AGENT: Final = "User-Agent"

--- a/custom_components/indego/lawn_mower.py
+++ b/custom_components/indego/lawn_mower.py
@@ -122,9 +122,9 @@ class IndegoLawnMower(IndegoEntity, LawnMowerEntity):
     @indego_state.setter
     def indego_state(self, indego_state: int):
         self._attr_indego_state = indego_state
-        self._attr_state = INDEGO_STATE_TO_LAWN_MOWER_MAPPING.get(indego_state)
+        self._attr_activity = INDEGO_STATE_TO_LAWN_MOWER_MAPPING.get(indego_state)
         _LOGGER.debug("Mower state updated to: %s", self._attr_state)
 
-        if self._attr_state is None:
+        if self._attr_activity is None:
             _LOGGER.warning("Received unsupported Indego mower state: %i", indego_state)
 

--- a/custom_components/indego/lawn_mower.py
+++ b/custom_components/indego/lawn_mower.py
@@ -1,0 +1,130 @@
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.lawn_mower import (
+    LawnMowerEntity,
+    LawnMowerEntityFeature,
+    LawnMowerActivity
+)
+from homeassistant.components.lawn_mower import (
+    DOMAIN as LAWN_MOWER_DOMAIN
+)
+
+from .const import DOMAIN
+from .mixins import IndegoEntity
+
+LAWN_MOWER_DOMAIN_FORMAT = LAWN_MOWER_DOMAIN + ".{}"
+
+STATE_MOWING = LawnMowerActivity.MOWING
+STATE_DOCKED = LawnMowerActivity.DOCKED
+STATE_PAUSED = LawnMowerActivity.PAUSED
+STATE_ERROR = LawnMowerActivity.ERROR
+# The Lawn Mower Entity as a limited amount of states
+STATE_IDLE = LawnMowerActivity.PAUSED
+STATE_RETURNING = LawnMowerActivity.MOWING
+
+
+_LOGGER = logging.getLogger(__name__)
+
+INDEGO_STATE_TO_LAWN_MOWER_MAPPING = {
+    0: STATE_DOCKED,
+    101: STATE_DOCKED,
+    257: STATE_DOCKED,
+    258: STATE_DOCKED,
+    259: STATE_DOCKED,
+    260: STATE_DOCKED,
+    261: STATE_DOCKED,
+    262: STATE_DOCKED,
+    263: STATE_DOCKED,
+    266: STATE_MOWING,
+    512: STATE_MOWING,
+    513: STATE_MOWING,
+    514: STATE_MOWING,
+    515: STATE_MOWING,
+    516: STATE_MOWING,
+    517: STATE_PAUSED,
+    518: STATE_MOWING,
+    519: STATE_IDLE,
+    520: STATE_MOWING,
+    521: STATE_MOWING,
+    522: STATE_MOWING,
+    523: STATE_MOWING,
+    524: STATE_MOWING,
+    525: STATE_MOWING,
+    768: STATE_RETURNING,
+    769: STATE_RETURNING,
+    770: STATE_RETURNING,
+    771: STATE_RETURNING,
+    772: STATE_RETURNING,
+    773: STATE_RETURNING,
+    774: STATE_RETURNING,
+    775: STATE_RETURNING,
+    776: STATE_RETURNING,
+    1005: STATE_MOWING,
+    1025: STATE_ERROR,
+    1026: STATE_ERROR,
+    1027: STATE_ERROR,
+    1038: STATE_ERROR,
+    1281: STATE_DOCKED,
+    1537: STATE_ERROR,
+    64513: STATE_DOCKED,
+    99999: STATE_ERROR,
+}
+
+INDEGO_LAWN_MOWER_FEATURES = (
+    LawnMowerEntityFeature.START_MOWING
+    | LawnMowerEntityFeature.DOCK
+    | LawnMowerEntityFeature.PAUSE
+)
+
+
+async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the lawn mower platform."""
+    async_add_entities(
+        [
+            entity
+            for entity in hass.data[DOMAIN][config_entry.entry_id].entities.values()
+            if isinstance(entity, IndegoLawnMower)
+        ]
+    )
+
+
+class IndegoLawnMower(IndegoEntity, LawnMowerEntity):
+
+    def __init__(self, entity_id, name, device_info: DeviceInfo, indego_hub):
+        super().__init__(LAWN_MOWER_DOMAIN_FORMAT.format(entity_id), name, "mdi:robot-mower", None, device_info)
+        self._indego_hub = indego_hub
+
+        self._attr_supported_features = INDEGO_LAWN_MOWER_FEATURES
+        self._attr_indego_state = None
+        self._attr_state = None
+
+    async def async_start_mowing(self) -> None:
+        await self._indego_hub.async_send_command_to_client("mow")
+
+    async def async_dock(self) -> None:
+        await self._indego_hub.async_send_command_to_client("returnToDock")
+
+    async def async_pause(self) -> None:
+        await self._indego_hub.async_send_command_to_client("pause")
+
+    @property
+    def indego_state(self) -> int:
+        return self._attr_indego_state
+
+    @indego_state.setter
+    def indego_state(self, indego_state: int):
+        self._attr_indego_state = indego_state
+        self._attr_state = INDEGO_STATE_TO_LAWN_MOWER_MAPPING.get(indego_state)
+        _LOGGER.debug("Mower state updated to: %s", self._attr_state)
+
+        if self._attr_state is None:
+            _LOGGER.warning("Received unsupported Indego mower state: %i", indego_state)
+


### PR DESCRIPTION
# Add Lawn Mower Entity

Home Assistant has a [native lawn mower entity](https://developers.home-assistant.io/docs/core/entity/lawn-mower) since version 2023.9 so I quickly added it.
It is based on the vacuum entity. The state mapping reflects the [husqvarna implementation](https://github.com/home-assistant/core/blob/dev/homeassistant/components/husqvarna_automower/lawn_mower.py).

![image](https://github.com/jm-73/Indego/assets/15942848/b0053323-1938-445a-b1e2-310941104cb4)
