### PR TITLE
Alerts with mower serial

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -98,18 +98,22 @@ SERVICE_SCHEMA_SMARTMOWING = vol.Schema({
 })
 
 SERVICE_SCHEMA_DELETE_ALERT = vol.Schema({
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
     vol.Required(CONF_DELETE_ALERT): cv.positive_int
 })
 
 SERVICE_SCHEMA_READ_ALERT = vol.Schema({
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
     vol.Required(CONF_READ_ALERT): cv.positive_int
 })
 
 SERVICE_SCHEMA_DELETE_ALERT_ALL = vol.Schema({
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
     vol.Required(CONF_DELETE_ALERT): cv.string
 })
 
 SERVICE_SCHEMA_READ_ALERT_ALL = vol.Schema({
+    vol.Optional(CONF_MOWER_SERIAL): cv.string,
     vol.Required(CONF_READ_ALERT): cv.string
 })
 
@@ -375,35 +379,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await instance._update_generic_data()
     async def async_delete_alert(call):
         """Handle the service call."""
+        instance = find_instance_for_mower_service_call(call)
         enable = call.data.get(CONF_DELETE_ALERT, DEFAULT_NAME_COMMANDS)
         _LOGGER.debug("Indego.delete_alert service called, with command: %s", enable)
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()
-        await hass.data[DOMAIN][entry.entry_id]._indego_client.delete_alert(enable)
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()     
+        await instance._update_alerts()
+        await instance._indego_client.delete_alert(enable)
+        await instance._update_alerts()     
 
     async def async_delete_alert_all(call):
         """Handle the service call."""
+        instance = find_instance_for_mower_service_call(call)
         enable = call.data.get(CONF_DELETE_ALERT, DEFAULT_NAME_COMMANDS)
         _LOGGER.debug("Indego.delete_alert_all service called, with command: %s", "all")
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()
-        await hass.data[DOMAIN][entry.entry_id]._indego_client.delete_all_alerts()
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()   
+        await instance._update_alerts()
+        await instance._indego_client.delete_all_alerts()
+        await instance._update_alerts()   
 
     async def async_read_alert(call):
         """Handle the service call."""
+        instance = find_instance_for_mower_service_call(call)
         enable = call.data.get(CONF_READ_ALERT, DEFAULT_NAME_COMMANDS)
         _LOGGER.debug("Indego.read_alert service called, with command: %s", enable)
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()
-        await hass.data[DOMAIN][entry.entry_id]._indego_client.put_alert_read(enable)
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()
+        await instance._update_alerts()
+        await instance._indego_client.put_alert_read(enable)
+        await instance._update_alerts()
 
     async def async_read_alert_all(call):
         """Handle the service call."""
+        instance = find_instance_for_mower_service_call(call)
         enable = call.data.get(CONF_READ_ALERT, DEFAULT_NAME_COMMANDS)
         _LOGGER.debug("Indego.read_alert_all service called, with command: %s", "all")
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()
-        await hass.data[DOMAIN][entry.entry_id]._indego_client.put_all_alerts_read()
-        await hass.data[DOMAIN][entry.entry_id]._update_alerts()
+        await instance._update_alerts()
+        await instance._indego_client.put_all_alerts_read()
+        await instance._update_alerts()
 
     # In HASS we can have multiple Indego component instances as long as the mower serial is unique.
     # So the mower services should only need to be registered for the first instance.

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -838,12 +838,12 @@ class IndegoHub:
             self.entities[ENTITY_ALERT_COUNT].state = 0
             self.entities[ENTITY_ALERT_ID].state = 0
             self.entities[ENTITY_ALERT_ERROR_CODE].state = 0
-            self.entities[ENTITY_ALERT_HEADLINE].state = "Kein Problem"
-            self.entities[ENTITY_ALERT_DATE].state = "Kein Problem"
-            self.entities[ENTITY_ALERT_MESSAGE].state = "Kein Problem"
+            self.entities[ENTITY_ALERT_HEADLINE].state = "No Problem"
+            self.entities[ENTITY_ALERT_DATE].state = "No Problem"
+            self.entities[ENTITY_ALERT_MESSAGE].state = "No Problem"
             self.entities[ENTITY_ALERT_READ_STATUS].state = False
             self.entities[ENTITY_ALERT_PUSH].state = False
-            self.entities[ENTITY_ALERT_DESCRIPTION].state = "Kein Problem"
+            self.entities[ENTITY_ALERT_DESCRIPTION].state = "No Problem"
 
         j = len(self._indego_client.alerts)
         # _LOGGER.info(f"Structuring ALERTS.{j}")

--- a/custom_components/indego/services.yaml
+++ b/custom_components/indego/services.yaml
@@ -23,23 +23,39 @@ smartmowing:
 delete_alert:
   description: Delete the selected Alert
   fields:
+    mower_serial:
+      description: The serial of the mower for this action. Only required when you have multiple mowers configured.
+      example: '"0123456789"'
+      required: false
     alert_index: 
       description: Delete the selected Alert in this case the latest
       example: "0"
 read_alert:
   description: Read the selected Alert
   fields:
+    mower_serial:
+      description: The serial of the mower for this action. Only required when you have multiple mowers configured.
+      example: '"0123456789"'
+      required: false
     alert_index: 
       description: marked the selected Alert as read
       example: "0"
 delete_alert_all:
   description: Delete the selected Alert
   fields:
+    mower_serial:
+      description: The serial of the mower for this action. Only required when you have multiple mowers configured.
+      example: '"0123456789"'
+      required: false
     alert_index: 
       description: Delete all Alerts
       example: "0"
 read_alert_all:
   description: Read the selected Alert
   fields:
+    mower_serial:
+      description: The serial of the mower for this action. Only required when you have multiple mowers configured.
+      example: '"0123456789"'
+      required: false
     alert_index: 
-      description: marked all Alerts as read
+      description: Mark all Alerts as read

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -1,0 +1,18 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Dieser Bosch Indego mower wurde bereits konfiguriert!",
+            "connection_error": "Die Verbindung zur Bosch Indego API ist fehlgeschlagen!",
+            "no_mowers_found": "In diesem Bosch Indego Account wurden keine Mäher gefunden!"
+        },
+        "step": {
+            "mower": {
+                "data": {
+                    "mower_serial": "Mäher Seriennummer",
+                    "mower_name": "Mäher Name"
+                },
+                "description": "Bitte die Seriennummer des Bosch Mähers, der hinzugefügt werden soll, auswählen"
+            }
+        }
+    }
+}

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -9,6 +9,8 @@
             "advanced": {
                 "data": {
                     "user_agent": "User-Agent"
+                    "expose_mower": "Indego Mäher als Mower Entität in HomeAssistant anlegen",
+                    "expose_vacuum": "Indego Mäher als Vacuum Entität in HomeAssistant anlegen"
                 },
                 "description": "Erweiterte Einstellung des Bosch Indego Component. Kann für die meisten Benutzer unverändert gelassen werden."
             },
@@ -27,7 +29,9 @@
                 "title": "Erweiterte Einstellung",
                 "description": "Erweiterte Einstellung des Bosch Indego Component.",
                 "data": {
-                    "user_agent": "User-Agent"
+                    "user_agent": "User-Agent",
+                    "expose_mower": "Indego Mäher als Mower Entität in HomeAssistant anlegen",
+                    "expose_vacuum": "Indego Mäher als Vacuum Entität in HomeAssistant anlegen"
                 }
             }
         }

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -6,12 +6,97 @@
             "no_mowers_found": "In diesem Bosch Indego Account wurden keine Mäher gefunden!"
         },
         "step": {
+            "advanced": {
+                "data": {
+                    "user_agent": "User-Agent"
+                },
+                "description": "Erweiterte Einstellung des Bosch Indego Component. Kann für die meisten Benutzer unverändert gelassen werden."
+            },
             "mower": {
                 "data": {
                     "mower_serial": "Mäher Seriennummer",
                     "mower_name": "Mäher Name"
                 },
                 "description": "Bitte die Seriennummer des Bosch Mähers, der hinzugefügt werden soll, auswählen"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Erweiterte Einstellung",
+                "description": "Erweiterte Einstellung des Bosch Indego Component.",
+                "data": {
+                    "user_agent": "User-Agent"
+                }
+            }
+        }
+    },
+    "services": {
+        "command": {
+            "description": "Befehle an den Mäher senden. Möglich Befehle sind mow, returnToDock und pause.",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähers. Wird nur benötigt wenn mehrere Mäher eingerichtet sind."
+                },
+                "command": {
+                    "description": "Befehl für den Mäher."
+                }
+            }
+        },
+        "smartmowing": {
+            "description": "SmartMowing aktivieren oder deaktivieren. Mögliche Befehle sind true oder false",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähers. Wird nur benötigt wenn mehrere Mäher eingerichtet sind."
+                },
+                "enable": {
+                    "description": "SmartMowing aktivieren."
+                }
+            }
+        },
+        "delete_alert": {
+            "description": "Löscht den ausgewählten Fehler",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähers. Wird nur benötigt wenn mehrere Mäher eingerichtet sind."
+                },
+                "alert_index": {
+                    "description": "Den ausgewählten Fehler löschen. Mit 0 wird der letzte/aktuellste Fehler gelöscht."
+                }
+            }
+        },
+        "delete_alert_all": {
+            "description": "Löscht alle Fehler",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähers. Wird nur benötigt wenn mehrere Mäher eingerichtet sind."
+                },
+                "alert_index": {
+                    "description": "Mit 0 werden alle Fehler gelöscht."
+                }
+            }
+        },
+        "read_alert": {
+            "description": "Markiert den ausgewählten Fehler als gelesen",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähers. Wird nur benötigt wenn mehrere Mäher eingerichtet sind."
+                },
+                "alert_index": {
+                    "description": "Den ausgewählten Fehler als gelesen markieren. Mit 0 wird der letzte/aktuellste Fehler ausgewählt."
+                }
+            }
+        },
+        "read_alert_all": {
+            "description": "Markiert alle Fehler als gelesen",
+            "fields": {
+                "mower_serial": {
+                    "description": "Seriennummer des Mähers. Wird nur benötigt wenn mehrere Mäher eingerichtet sind."
+                },
+                "alert_index": {
+                    "description": "Mit 0 werden alle Fehler als gelesen markiert."
+                }
             }
         }
     }

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -8,7 +8,9 @@
         "step": {
             "advanced": {
                 "data": {
-                    "user_agent": "User-Agent"
+                    "user_agent": "User-Agent",
+                    "expose_mower": "Expose Indego mower as mower entity in HomeAssistant",
+                    "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant"
                 },
                 "description": "Advanced settings of the Bosch Indego component. Can be left unchanged for most users."
             },
@@ -25,11 +27,12 @@
       "step": {
           "init": {
               "title": "Advanced settings",
-              "description": "Advanced settings of the Bosch Indego component.",
+              "description": "Advanced settings of the Bosch Indego component. You might have to reload the component after changing these settings.",
               "data": {
-                  "user_agent": "User-Agent"
+                  "user_agent": "User-Agent",
+                  "expose_mower": "Expose Indego mower as mower entity in HomeAssistant",
+                  "expose_vacuum": "Expose Indego mower as vacuum entity in HomeAssistant"
               }
           }
       }
     }
-}

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -35,4 +35,73 @@
               }
           }
       }
+    },
+    "services": {
+        "command": {
+            "description": "Send commands to the mower. Allowed commands are mow, returnToDock and pause.",
+            "fields": {
+                "mower_serial": {
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "command": {
+                    "description": "Command for the mower"
+                }
+            }
+        },
+        "smartmowing": {
+            "description": "Enable or Disable SmartMowing. Allowed commands are true or false",
+            "fields": {
+                "mower_serial": {
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "enable": {
+                    "description": "Enable SmartMowing."
+                }
+            }
+        },
+        "delete_alert": {
+            "description": "Löscht den ausgewählten Fehler",
+            "fields": {
+                "mower_serial": {
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "alert_index": {
+                    "description": "Den ausgewählten Fehler löschen. Mit 0 wird der letzte/aktuellste Fehler gelöscht."
+                }
+            }
+        },
+        "delete_alert_all": {
+            "description": "Löscht alle Fehler",
+            "fields": {
+                "mower_serial": {
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "alert_index": {
+                    "description": "Mit 0 werden alle Fehler gelöscht."
+                }
+            }
+        },
+        "read_alert": {
+            "description": "Markiert den ausgewählten Fehler als gelesen",
+            "fields": {
+                "mower_serial": {
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "alert_index": {
+                    "description": "Den ausgewählten Fehler als gelesen markieren. Mit 0 wird der letzte/aktuellste Fehler ausgewählt."
+                }
+            }
+        },
+        "read_alert_all": {
+            "description": "Markiert alle Fehler als gelesen",
+            "fields": {
+                "mower_serial": {
+                    "description": "Mower serial. Only needed when you have configured multiple mowers."
+                },
+                "alert_index": {
+                    "description": "Mit 0 werden alle Fehler als gelesen markiert."
+                }
+            }
+        }
     }
+}

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -60,13 +60,13 @@
             }
         },
         "delete_alert": {
-            "description": "Löscht den ausgewählten Fehler",
+            "description": "Delete the selected Alert",
             "fields": {
                 "mower_serial": {
                     "description": "Mower serial. Only needed when you have configured multiple mowers."
                 },
                 "alert_index": {
-                    "description": "Den ausgewählten Fehler löschen. Mit 0 wird der letzte/aktuellste Fehler gelöscht."
+                    "description": "Delete the selected Alert. 0 for the latest Alert"
                 }
             }
         },

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -71,35 +71,35 @@
             }
         },
         "delete_alert_all": {
-            "description": "Löscht alle Fehler",
+            "description": "Delete all Alerts",
             "fields": {
                 "mower_serial": {
                     "description": "Mower serial. Only needed when you have configured multiple mowers."
                 },
                 "alert_index": {
-                    "description": "Mit 0 werden alle Fehler gelöscht."
+                    "description": "Delete all alerts with 0"
                 }
             }
         },
         "read_alert": {
-            "description": "Markiert den ausgewählten Fehler als gelesen",
+            "description": "mark the selected alert as read.",
             "fields": {
                 "mower_serial": {
                     "description": "Mower serial. Only needed when you have configured multiple mowers."
                 },
                 "alert_index": {
-                    "description": "Den ausgewählten Fehler als gelesen markieren. Mit 0 wird der letzte/aktuellste Fehler ausgewählt."
+                    "description": "Mark the selected alert as read. 0 for the latest alert."
                 }
             }
         },
         "read_alert_all": {
-            "description": "Markiert alle Fehler als gelesen",
+            "description": "Mark all alerts as read",
             "fields": {
                 "mower_serial": {
                     "description": "Mower serial. Only needed when you have configured multiple mowers."
                 },
                 "alert_index": {
-                    "description": "Mit 0 werden alle Fehler als gelesen markiert."
+                    "description": "Mark all alerts as read with 0."
                 }
             }
         }


### PR DESCRIPTION
Added the mower serial to the alert features to be able to select the mower when multiple mowers are configured.
Mower serial is optional and must not be used when only one mower is configured.
Also added de.json translation file.

Used developer branch with version 5.6.2 as base.