### PR TITLE
Fix service set_calendar_slot

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -656,7 +656,7 @@ def _calendar_to_payload(calendar, selected_cal: int = 1) -> dict:
         "sel_cal": selected_cal,
         "cals": [
             {
-                "cal": getattr(calendar, "cal", selected_cal) if calendar else selected_cal,
+                "cal": selected_cal,
                 "days": days,
             }
         ],

--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -1408,7 +1408,7 @@ class IndegoHub:
         start: str | None = None,
         end: str | None = None,
     ):
-        """Set one calendar slot."""
+        """Set one manual calendar slot."""
         _LOGGER.info(
             "Setting calendar slot: days=%s slot=%s enabled=%s start=%s end=%s mower=%s",
             days,
@@ -1419,33 +1419,34 @@ class IndegoHub:
             self._serial,
         )
 
-        # Validierung der Zeiten, falls enabled
         if enabled:
             if not start or not end:
-                raise ValueError("start and end are required when enabled is true")
+                raise HomeAssistantError(
+                    "start and end are required when enabled is true"
+                )
+
             try:
                 _parse_slot_time(start)
                 _parse_slot_time(end)
-            except ValueError as e:
-                _LOGGER.error("Invalid time format for slot: %s", e)
-                raise HomeAssistantError(f"Invalid time format: {e}") from e
+            except ValueError as err:
+                _LOGGER.error("Invalid time format for slot: %s", err)
+                raise HomeAssistantError(f"Invalid time format: {err}") from err
 
         await self._indego_client.update_calendar()
         calendar = getattr(self._indego_client, "calendar", None)
 
-        payload = _calendar_to_payload(calendar, selected_cal=1)
+        payload = _calendar_to_payload(calendar, selected_cal=2)
+
         for day in days:
             payload = _set_payload_slot(payload, day, slot, enabled, start, end)
 
-        # Experimental: pyIndego documents GET /calendar, but not PUT /calendar.
-        result = await self._indego_client.put(
+        await self._indego_client.put(
             f"alms/{self._serial}/calendar",
             payload,
         )
 
-        _LOGGER.warning("SET CALENDAR SLOT RESULT = %r", result)
-
         await self._update_calendar()
+        await self._update_next_mow()
 
     async def async_select_manual_calendar(self):
         """Try to select the manual calendar after SmartMowing was disabled."""

--- a/custom_components/indego/translations/da.json
+++ b/custom_components/indego/translations/da.json
@@ -648,7 +648,7 @@
                     "name": "Kalendertype",
                     "description": "Vælg kalender ('calendar' for manuel kalender oder 'predictive' for deaktiverede tidsrum i SmartMowing-tilstand)."
                 },
-                "day": {
+                "days": {
                     "name": "Dag",
                     "description": "Navnet på den ugedag, der skal konfigureres."
                 },

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -648,7 +648,7 @@
                     "name": "Kalender Typ",
                     "description": "Kalender auswählen ('calendar' für manuellen Kalender oder 'predictive' für deaktivierte Zeiten im SmartMowing Modus)."
                 },
-                "day": {
+                "days": {
                     "name": "Tag",
                     "description": "Name des Wochentags der konfiguriert werden soll"
                 },

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -648,7 +648,7 @@
                     "name": "Calendar Type",
                     "description": "Type of calendar to use. Use 'calendar' for manual calendar or 'predictive' for the forbidden time slots in SmartMowing mode."
                 },
-                "day": {
+                "days": {
                     "name": "Day",
                     "description": "Which day to configure.",
                     "example": "Montag"

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -638,7 +638,7 @@
                     "name": "Tipo de calendario",
                     "description": "Selecciona el calendario ('calendar' para el calendario manual o 'predictive' para los períodos desactivados en el modo SmartMowing)."
                 },
-                "day": {
+                "days": {
                     "name": "Día",
                     "description": "Nombre del día de la semana que se va a configurar."
                 },

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -638,7 +638,7 @@
                     "name": "Type de calendrier",
                     "description": "Sélectionnez le calendrier ('calendar' pour le calendrier manuel ou 'predictive' pour les périodes désactivées en mode SmartMowing)."
                 },
-                "day": {
+                "days": {
                     "name": "Jour",
                     "description": "Nom du jour de la semaine à configurer."
                 },

--- a/custom_components/indego/translations/it.json
+++ b/custom_components/indego/translations/it.json
@@ -638,7 +638,7 @@
                     "name": "Tipo di calendario",
                     "description": "Seleziona il calendario ('calendar' per il calendario manuale o 'predictive' per i periodi disattivati in modalità SmartMowing)."
                 },
-                "day": {
+                "days": {
                     "name": "Giorno",
                     "description": "Nome del giorno della settimana da configurare."
                 },

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -638,7 +638,7 @@
                     "name": "Kalendertype",
                     "description": "Selecteer de kalender ('calendar' voor de handmatige kalender of 'predictive' voor gedeactiveerde tijden in SmartMowing-modus)."
                 },
-                "day": {
+                "days": {
                     "name": "Dag",
                     "description": "Naam van de weekdag die moet worden geconfigureerd."
                 },

--- a/custom_components/indego/translations/no.json
+++ b/custom_components/indego/translations/no.json
@@ -638,7 +638,7 @@
                     "name": "Kalendertype",
                     "description": "Velg kalender ('calendar' for manuell kalender eller 'predictive' for deaktiverte tidsrom i SmartMowing-modus)."
                 },
-                "day": {
+                "days": {
                     "name": "Dag",
                     "description": "Navnet på ukedagen som skal konfigureres."
                 },

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -638,7 +638,7 @@
                     "name": "Typ kalendarza",
                     "description": "Wybierz kalendarz ('calendar' dla kalendarza ręcznego lub 'predictive' dla dezaktywowanych okresów w trybie SmartMowing)."
                 },
-                "day": {
+                "days": {
                     "name": "Dzień",
                     "description": "Nazwa dnia tygodnia, który ma zostać skonfigurowany."
                 },

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -638,7 +638,7 @@
                     "name": "Typ kalendára",
                     "description": "Vyberte kalendár ('calendar' pre manuálny kalendár alebo 'predictive' pre deaktivované časové obdobia v režime SmartMowing)."
                 },
-                "day": {
+                "days": {
                     "name": "Deň",
                     "description": "Názov dňa v týždni, ktorý sa má nakonfigurovať."
                 },

--- a/custom_components/indego/translations/sv.json
+++ b/custom_components/indego/translations/sv.json
@@ -638,7 +638,7 @@
                     "name": "Kalendertyp",
                     "description": "Välj kalender ('calendar' för den manuella kalendern eller 'predictive' för inaktiverade tidsperioder i SmartMowing-läge)."
                 },
-                "day": {
+                "days": {
                     "name": "Dag",
                     "description": "Namnet på veckodagen som ska konfigureras."
                 },


### PR DESCRIPTION
Fixed some bugs in the service indego.set_calendar_slot 
1. The calendar was transferred to the Bosch App but the wrong calendar mode was selected. This caused that the mower didnt start at the planned mow time. 
2. The entity *_next_mow now gets updated directly after the service call. 
3. There was a missing "s" in the translation files so in the service set_calendar_slot there was always the english text for the day selection.