### PR TITLE
Fix predictive schedule translations and list index error

### DIFF
--- a/custom_components/indego/__init__.py
+++ b/custom_components/indego/__init__.py
@@ -1969,15 +1969,19 @@ class IndegoHub:
         await self._update_security()
 
     async def _update_automatic_update(self):
-        automatic_update = await self._indego_client.get(
-            f"alms/{self._serial}/automaticUpdate"
-        )
-
+        try:
+            automatic_update = await self._indego_client.get(
+                f"alms/{self._serial}/automaticUpdate"
+            )
+        except Exception as exc:
+            _LOGGER.warning("Failed to fetch automatic update data: %s", exc)
+            return None
+    
         if ENTITY_AUTOMATIC_UPDATE in self.entities:
             self.entities[ENTITY_AUTOMATIC_UPDATE].is_on = bool(
                 automatic_update.get("allow_automatic_update")
             )
-
+    
         return automatic_update
 
     async def async_set_automatic_update(self, enabled: bool):
@@ -2591,22 +2595,30 @@ class IndegoHub:
         )
 
     async def _update_predictive_weather(self):
-        weather = await self._indego_client.get(
-            f"alms/{self._serial}/predictive/weather"
-        )
-
+        try:
+            weather = await self._indego_client.get(
+                f"alms/{self._serial}/predictive/weather"
+            )
+        except Exception as exc:
+            _LOGGER.warning("Failed to fetch predictive weather data: %s", exc)
+            return None
+    
         self._predictive_weather = weather
-
+    
         if ENTITY_PREDICTIVE_WEATHER in self.entities:
             self.entities[ENTITY_PREDICTIVE_WEATHER].weather_data = weather
-
+    
         return weather
 
     async def _update_calendar(self):
         """Update calendar data / planned mowing slots."""
         _LOGGER.debug("Fetching calendar from Bosch API")
 
-        await self._indego_client.update_calendar()
+        try:
+            await self._indego_client.update_calendar()
+        except Exception as exc:
+            _LOGGER.warning("Failed to fetch calendar data: %s", exc)
+            return None
 
         calendar = getattr(self._indego_client, "calendar", None)
 

--- a/custom_components/indego/translations/da.json
+++ b/custom_components/indego/translations/da.json
@@ -479,6 +479,7 @@
                 "name": "SmartMowing-tidsplan",
                 "state": {
                     "manual_calendar_active": "Manuel kalender aktiv",
+                    "not_scheduled": "Ikke planlagt",
                     "none": "Ingen"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/de.json
+++ b/custom_components/indego/translations/de.json
@@ -321,6 +321,7 @@
                 "name": "SmartMowing Zeitplan",
                 "state": {
                     "manual_calendar_active": "Manueller Kalender aktiv",
+                    "not_scheduled": "Nicht geplant",
                     "none": "Keine"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/en.json
+++ b/custom_components/indego/translations/en.json
@@ -384,6 +384,7 @@
                 "name": "SmartMowing schedule",
                 "state": {
                     "manual_calendar_active": "Manual calendar active",
+                    "not_scheduled": "Not scheduled",
                     "none": "None"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/es.json
+++ b/custom_components/indego/translations/es.json
@@ -444,6 +444,7 @@
                 "name": "Horario de SmartMowing",
                 "state": {
                     "manual_calendar_active": "Calendario manual activo",
+                    "not_scheduled": "No programado",
                     "none": "Ninguno"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/fr.json
+++ b/custom_components/indego/translations/fr.json
@@ -444,6 +444,7 @@
                 "name": "Programme SmartMowing",
                 "state": {
                     "manual_calendar_active": "Calendrier manuel actif",
+                    "not_scheduled": "Non planifié",
                     "none": "Aucun"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/it.json
+++ b/custom_components/indego/translations/it.json
@@ -444,6 +444,7 @@
                 "name": "Programma SmartMowing",
                 "state": {
                     "manual_calendar_active": "Calendario manuale attivo",
+                    "not_scheduled": "Non pianificato",
                     "none": "Nessuno"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/nl.json
+++ b/custom_components/indego/translations/nl.json
@@ -444,6 +444,7 @@
                 "name": "SmartMowing-schema",
                 "state": {
                     "manual_calendar_active": "Handmatige kalender actief",
+                    "not_scheduled": "Niet gepland",
                     "none": "Geen"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/no.json
+++ b/custom_components/indego/translations/no.json
@@ -444,6 +444,7 @@
                 "name": "SmartMowing-tidsplan",
                 "state": {
                     "manual_calendar_active": "Manuell kalender aktiv",
+                    "not_scheduled": "Ikke planlagt",
                     "none": "Ingen"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/pl.json
+++ b/custom_components/indego/translations/pl.json
@@ -444,6 +444,7 @@
                 "name": "Harmonogram SmartMowing",
                 "state": {
                     "manual_calendar_active": "Aktywny kalendarz ręczny",
+                    "not_scheduled": "Nie zaplanowano",
                     "none": "Brak"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/sk.json
+++ b/custom_components/indego/translations/sk.json
@@ -444,6 +444,7 @@
                 "name": "Plán SmartMowing",
                 "state": {
                     "manual_calendar_active": "Manuálny kalendár aktívny",
+                    "not_scheduled": "Nenaplánované",
                     "none": "Žiadne"
                 },
                 "state_attributes": {

--- a/custom_components/indego/translations/sv.json
+++ b/custom_components/indego/translations/sv.json
@@ -444,6 +444,7 @@
                 "name": "SmartMowing-schema",
                 "state": {
                     "manual_calendar_active": "Manuell kalender aktiv",
+                    "not_scheduled": "Inte schemalagd",
                     "none": "Ingen"
                 },
                 "state_attributes": {


### PR DESCRIPTION
Added translations in all languages for the state "not_scheduled" of the entity sensor.indego_XXXXXX_predictive_schedule. 
Additionally added a check for async def _update_calendar(self), async def _update_predictive_weather(self) and async def _update_automatic_update(self) to prevent checking against an empty field after 500 error. These checks werde missing in PR #300 